### PR TITLE
Fix import from non-existent directory

### DIFF
--- a/DEODR/_differentiable_renderer.pxd
+++ b/DEODR/_differentiable_renderer.pxd
@@ -1,6 +1,6 @@
 # distutils: language=c++
 from libcpp cimport bool
-cdef extern from "../c++/DifferentiableRenderer.h":
+cdef extern from "../C++/DifferentiableRenderer.h":
 	ctypedef struct Scene:
 		unsigned int* faces;
 		unsigned int* faces_uv;


### PR DESCRIPTION
Tried to build on ubuntu and was unable to. 
```
DEODR/differentiable_renderer_cython.cpp:624:10: fatal error: ../c++/DifferentiableRenderer.h: No such file or directory
 #include "../c++/DifferentiableRenderer.h"
```
This seems like a typo