### PR TITLE
removing hard coded zmin and zmax in opengl rendering

### DIFF
--- a/deodr/differentiable_renderer.py
+++ b/deodr/differentiable_renderer.py
@@ -504,9 +504,7 @@ class Scene2D(Scene2DBase):
         z_buffer = np.zeros((self.height, self.width))
         err_buffer = np.empty((self.height, self.width))
         antialiase_error = True
-        renderScene(
-            self, sigma, image, z_buffer, antialiase_error, obs, err_buffer
-        )
+        renderScene(self, sigma, image, z_buffer, antialiase_error, obs, err_buffer)
         self.store_backward = (sigma, obs, image, z_buffer, err_buffer)
         return image, z_buffer, err_buffer
 
@@ -514,9 +512,7 @@ class Scene2D(Scene2DBase):
         image = np.zeros((self.height, self.width, self.nb_colors))
         z_buffer = np.zeros((self.height, self.width))
         antialiase_error = False
-        renderScene(
-            self, sigma, image, z_buffer, antialiase_error, None, None
-        )
+        renderScene(self, sigma, image, z_buffer, antialiase_error, None, None)
         self.store_backward = (sigma, image, z_buffer)
         return image, z_buffer
 
@@ -717,9 +713,7 @@ class Scene3D:
         ij, colors, image, z_buffer = self.store_backward_current["render_2d"]
         self.ij = np.array(ij)
         self.colors = np.array(colors)
-        renderSceneB(
-            self, self.sigma, image.copy(), z_buffer, image_b
-        )
+        renderSceneB(self, self.sigma, image.copy(), z_buffer, image_b)
         return self.ij_b, self.colors_b
 
     def render(self, camera, return_z_buffer=False, backface_culling=True):

--- a/deodr/examples/mesh_viewer.py
+++ b/deodr/examples/mesh_viewer.py
@@ -142,6 +142,8 @@ def mesh_viewer(
     display_fps=True,
     title=None,
     use_moderngl=False,
+    zfar=None,
+    znear=None,
 ):
     if type(obj_file_or_trimesh) == str:
         if title is None:
@@ -160,6 +162,7 @@ def mesh_viewer(
         )
 
     mesh = ColoredTriMesh.from_trimesh(mesh_trimesh)
+
     if display_texture_map:
         ax = plt.subplot(111)
         if mesh.textured:
@@ -170,6 +173,13 @@ def mesh_viewer(
 
     camera_center = object_center + np.array([0, 0, 3]) * object_radius
     focal = 2 * width
+
+    if zfar is None:
+        zfar = (
+            10 * (np.sqrt(np.sum((camera_center - object_center) ** 2))) + object_radius
+        )
+    if znear is None:
+        znear = zfar * 0.0001
 
     rotation = np.array([[1, 0, 0], [0, -1, 0], [0, 0, -1]])
     translation = -rotation.T.dot(camera_center)
@@ -212,7 +222,9 @@ def mesh_viewer(
     if use_moderngl:
         import deodr.opengl.moderngl
 
-        offscreen_renderer = deodr.opengl.moderngl.OffscreenRenderer()
+        offscreen_renderer = deodr.opengl.moderngl.OffscreenRenderer(
+            znear=znear, zfar=zfar
+        )
         scene.mesh.compute_vertex_normals()
     while cv2.getWindowProperty(windowname, 0) >= 0:
         # mesh.set_vertices(mesh.vertices+np.random.randn(*mesh.vertices.shape)*0.001)
@@ -246,7 +258,7 @@ def mesh_viewer(
 
 def run():
     obj_file = os.path.join(deodr.data_path, "duck.obj")
-    mesh_viewer(obj_file, use_moderngl=False)
+    mesh_viewer(obj_file, use_moderngl=True)
 
 
 if __name__ == "__main__":

--- a/deodr/examples/render_mesh.py
+++ b/deodr/examples/render_mesh.py
@@ -133,7 +133,7 @@ def example_moderngl(display=True, width=640, height=480):
     camera.extrinsic[1, 1] = camera.extrinsic[1, 1] * 0.9
 
     image_no_antialiasing = scene.render(camera)
-    moderngl_renderer = deodr.opengl.moderngl.OffscreenRenderer()
+    moderngl_renderer = deodr.opengl.moderngl.OffscreenRenderer(znear=0.1, zfar=1000)
     image_moderngl = moderngl_renderer.render(scene, camera)
     diff = np.abs(
         image_no_antialiasing.astype(np.float) * 255 - image_moderngl.astype(np.float)

--- a/tests/test_render_mesh.py
+++ b/tests/test_render_mesh.py
@@ -26,3 +26,4 @@ def test_render_mesh(update=False):
 
 if __name__ == "__main__":
     test_render_mesh()
+    test_render_mesh_moderngl()


### PR DESCRIPTION
we had hard coded znear and zfar when dooing opengl rendering. Now we are forced to provide values instead of using arbitrary hard coded values