### PR TITLE
Adding barycentric coordinates rendering in deferred rendering

### DIFF
--- a/create_venv.bat
+++ b/create_venv.bat
@@ -1,5 +1,5 @@
 python -m venv python_venv
 .\python_venv\scripts\python.exe -m pip install --upgrade pip
-.\python_venv\scripts\pip.exe install torch===1.4.0 torchvision===0.5.0 -f https://download.pytorch.org/whl/torch_stable.html
+.\python_venv\scripts\pip.exe install torch===1.6.0 torchvision===0.5.0 -f https://download.pytorch.org/whl/torch_stable.html
 .\python_venv\scripts\pip.exe install -r requirements.txt
 .\python_venv\scripts\pip.exe install -e .

--- a/deodr/differentiable_renderer.py
+++ b/deodr/differentiable_renderer.py
@@ -836,6 +836,7 @@ class Scene3D:
         color=True,
         depth=True,
         face_id=True,
+        barycentric=True,
         normal=True,
         luminosity=True,
         uv=True,
@@ -880,6 +881,11 @@ class Scene3D:
                 np.arange(0, self.mesh.nb_faces)[:, None], (1, 3)
             ).reshape(soup_nb_vertices, 1)
             channels["face_id"] = soup_face_ids
+        if barycentric:
+            soup_barycentric = np.tile(
+                np.eye(3, 3)[None, :, :], (self.mesh.nb_faces, 1, 1)
+            ).reshape(soup_nb_vertices, 3)
+            channels["barycentric"] = soup_barycentric
         if normal:
             soup_normals = self.mesh.vertex_normals[self.mesh.faces].reshape(
                 soup_nb_vertices, 3

--- a/deodr/examples/render_mesh.py
+++ b/deodr/examples/render_mesh.py
@@ -83,7 +83,7 @@ def example_channels(display=True, save_image=False, width=640, height=480):
     if display:
         plt.figure()
         for i, (name, v) in enumerate(channels.items()):
-            ax = plt.subplot(2, 3, i + 1)
+            ax = plt.subplot(2, 4, i + 1)
             ax.set_title(name)
             ax.imshow(normalize(v))
 
@@ -133,7 +133,7 @@ def example_moderngl(display=True, width=640, height=480):
     camera.extrinsic[1, 1] = camera.extrinsic[1, 1] * 0.9
 
     image_no_antialiasing = scene.render(camera)
-    moderngl_renderer = deodr.opengl.moderngl.OffscreenRenderer()
+    moderngl_renderer = deodr.opengl.moderngl.OffscreenRenderer(znear=0.1, zfar=10)
     image_moderngl = moderngl_renderer.render(scene, camera)
     diff = np.abs(
         image_no_antialiasing.astype(np.float) * 255 - image_moderngl.astype(np.float)
@@ -160,7 +160,7 @@ def example_moderngl(display=True, width=640, height=480):
 
 
 if __name__ == "__main__":
-    example_moderngl(display=False)
+    example_moderngl(display=True)
     example_rgb(save_image=False)
     example_channels(save_image=False)
     example_pyrender()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ torch==1.6.0
 tensorflow==2.3.1
 moderngl==5.6.2
 pyrr==0.10.3
+pyrender==0.1.39
 pytest-xvfb==2.0.0
 flake8==3.8.3
 flake8-quotes==3.2.0


### PR DESCRIPTION
In some case it might be able to get both the face id and the barycentric coordinate within the face for each pixel in the rasterized image. This provides the barycentric coordinates as one of the channels that can be generated by the deferred rendering method