### PR TITLE
Non square texture fixes and minor improvements

### DIFF
--- a/deodr/differentiable_renderer.py
+++ b/deodr/differentiable_renderer.py
@@ -829,7 +829,6 @@ class Scene3D:
             ij_b, depths_b=depths_b, store_backward=self.store_backward_current
         )
 
-
     def render_deferred(
         self,
         camera,

--- a/deodr/differentiable_renderer.py
+++ b/deodr/differentiable_renderer.py
@@ -785,7 +785,7 @@ class Scene3D:
         if self.light_directional is not None:
             self.mesh.compute_vertex_normals_backward(self.vertex_normals_b)
 
-    def render_depth(self, camera, height, width, depth_scale=1, backface_culling=True):
+    def render_depth(self, camera, depth_scale=1, backface_culling=True):
         self.store_backward_current = {}
         points_2d, depths = camera.project_points(
             self.mesh.vertices, store_backward=self.store_backward_current
@@ -807,8 +807,8 @@ class Scene3D:
         self.shade = np.zeros(
             (self.mesh.nb_vertices), dtype=np.bool
         )  # eventually used when using texture
-        self.height = height
-        self.width = width
+        self.height = camera.height
+        self.width = camera.width
         self.shaded = np.zeros(
             (self.mesh.nb_faces), dtype=np.bool
         )  # eventually used when using texture
@@ -828,6 +828,7 @@ class Scene3D:
         self.mesh.vertices_b = camera.project_points_backward(
             ij_b, depths_b=depths_b, store_backward=self.store_backward_current
         )
+
 
     def render_deferred(
         self,

--- a/deodr/examples/mesh_viewer.py
+++ b/deodr/examples/mesh_viewer.py
@@ -65,8 +65,14 @@ class Interactor:
         if event == cv2.EVENT_MBUTTONUP:
             self.middle_is_down = False
 
-        if self.left_is_down:
+
+        self.ctrl_is_down =  flags & cv2.EVENT_FLAG_CTRLKEY
+
+        if self.left_is_down and not(self.ctrl_is_down):
+            
             if self.mode == "camera_centered":
+                print(center_in_camera)
+                center_in_camera= self.camera.world_to_camera(self.object_center)
                 rotation = Rotation.from_rotvec(
                     np.array(
                         [
@@ -77,8 +83,10 @@ class Interactor:
                     )
                 )
                 self.camera.extrinsic = rotation.as_dcm().dot(self.camera.extrinsic)
+                # assert np.allclose(center_in_camera, self.camera.world_to_camera(self.object_center))
                 self.x_last = x
                 self.y_last = y
+
             if self.mode == "object_centered_trackball":
 
                 rotation = Rotation.from_rotvec(
@@ -102,7 +110,7 @@ class Interactor:
             else:
                 raise (BaseException(f"unknown camera mode {self.mode}"))
 
-        if self.right_is_down:
+        if self.right_is_down and not(self.ctrl_is_down):
             if self.mode == "camera_centered":
                 self.camera.extrinsic[2, 3] += self.z_translation_speed * (
                     self.y_last - y
@@ -118,20 +126,29 @@ class Interactor:
             else:
                 raise (BaseException(f"unknown camera mode {self.mode}"))
 
-        if self.middle_is_down:
+        if self.middle_is_down or (self.left_is_down and self.ctrl_is_down):
+            # translation
+            
             object_depth = (
                 self.camera.extrinsic[2, :3].dot(self.object_center)
                 + self.camera.extrinsic[2, 3]
             )
 
-            self.camera.extrinsic[0, 3] += (
+            
+            tx = (
                 self.xy_translation_speed * object_depth * (x - self.x_last)
             )
-            self.camera.extrinsic[1, 3] += (
+            ty=  (
                 self.xy_translation_speed * object_depth * (y - self.y_last)
             )
+
+            self.object_center -= self.camera.extrinsic[0,:3] * tx + self.camera.extrinsic[1,:3] * ty
+            self.camera.extrinsic[0, 3] += tx
+            self.camera.extrinsic[1, 3] += ty
+            center_in_camera= self.camera.world_to_camera(self.object_center)            
             self.x_last = x
             self.y_last = y
+            assert np.max(np.abs(center_in_camera[:2])) < 1e-3
 
 
 def mesh_viewer(
@@ -142,8 +159,9 @@ def mesh_viewer(
     display_fps=True,
     title=None,
     use_moderngl=False,
-    zfar=None,
-    znear=None,
+    light_directional=(-0.5, 0, -0.5), 
+    light_ambient=0.3
+    
 ):
     if type(obj_file_or_trimesh) == str:
         if title is None:
@@ -162,7 +180,6 @@ def mesh_viewer(
         )
 
     mesh = ColoredTriMesh.from_trimesh(mesh_trimesh)
-
     if display_texture_map:
         ax = plt.subplot(111)
         if mesh.textured:
@@ -173,13 +190,6 @@ def mesh_viewer(
 
     camera_center = object_center + np.array([0, 0, 3]) * object_radius
     focal = 2 * width
-
-    if zfar is None:
-        zfar = (
-            10 * (np.sqrt(np.sum((camera_center - object_center) ** 2))) + object_radius
-        )
-    if znear is None:
-        znear = zfar * 0.0001
 
     rotation = np.array([[1, 0, 0], [0, -1, 0], [0, 0, -1]])
     translation = -rotation.T.dot(camera_center)
@@ -196,7 +206,7 @@ def mesh_viewer(
     )
 
     scene = differentiable_renderer.Scene3D()
-    scene.set_light(light_directional=np.array([-0.5, 0, -0.5]), light_ambient=0.3)
+    scene.set_light(light_directional=np.array(light_directional), light_ambient=light_ambient)
     scene.set_mesh(mesh)
     background_image = np.ones((height, width, 3))
     scene.set_background(background_image)
@@ -213,7 +223,7 @@ def mesh_viewer(
         camera=camera,
         object_center=object_center,
         z_translation_speed=0.01 * object_radius,
-        xy_translation_speed=1e-7 * object_radius,
+        xy_translation_speed=3e-4,
     )
 
     cv2.namedWindow(windowname)
@@ -222,15 +232,15 @@ def mesh_viewer(
     if use_moderngl:
         import deodr.opengl.moderngl
 
-        offscreen_renderer = deodr.opengl.moderngl.OffscreenRenderer(
-            znear=znear, zfar=zfar
-        )
+        offscreen_renderer = deodr.opengl.moderngl.OffscreenRenderer()
         scene.mesh.compute_vertex_normals()
+        offscreen_renderer.set_scene(scene)
+
     while cv2.getWindowProperty(windowname, 0) >= 0:
         # mesh.set_vertices(mesh.vertices+np.random.randn(*mesh.vertices.shape)*0.001)
         start = time.clock()
         if use_moderngl:
-            image = offscreen_renderer.render(scene, camera)
+            image = offscreen_renderer.render(camera)
         else:
             image = scene.render(interactor.camera)
 
@@ -258,7 +268,7 @@ def mesh_viewer(
 
 def run():
     obj_file = os.path.join(deodr.data_path, "duck.obj")
-    mesh_viewer(obj_file, use_moderngl=True)
+    mesh_viewer(obj_file, use_moderngl=False)
 
 
 if __name__ == "__main__":

--- a/deodr/examples/mesh_viewer.py
+++ b/deodr/examples/mesh_viewer.py
@@ -65,14 +65,13 @@ class Interactor:
         if event == cv2.EVENT_MBUTTONUP:
             self.middle_is_down = False
 
+        self.ctrl_is_down = flags & cv2.EVENT_FLAG_CTRLKEY
 
-        self.ctrl_is_down =  flags & cv2.EVENT_FLAG_CTRLKEY
+        if self.left_is_down and not (self.ctrl_is_down):
 
-        if self.left_is_down and not(self.ctrl_is_down):
-            
             if self.mode == "camera_centered":
-                print(center_in_camera)
-                center_in_camera= self.camera.world_to_camera(self.object_center)
+
+                center_in_camera = self.camera.world_to_camera(self.object_center)
                 rotation = Rotation.from_rotvec(
                     np.array(
                         [
@@ -110,7 +109,7 @@ class Interactor:
             else:
                 raise (BaseException(f"unknown camera mode {self.mode}"))
 
-        if self.right_is_down and not(self.ctrl_is_down):
+        if self.right_is_down and not (self.ctrl_is_down):
             if self.mode == "camera_centered":
                 self.camera.extrinsic[2, 3] += self.z_translation_speed * (
                     self.y_last - y
@@ -128,24 +127,21 @@ class Interactor:
 
         if self.middle_is_down or (self.left_is_down and self.ctrl_is_down):
             # translation
-            
+
             object_depth = (
                 self.camera.extrinsic[2, :3].dot(self.object_center)
                 + self.camera.extrinsic[2, 3]
             )
 
-            
-            tx = (
-                self.xy_translation_speed * object_depth * (x - self.x_last)
-            )
-            ty=  (
-                self.xy_translation_speed * object_depth * (y - self.y_last)
-            )
+            tx = self.xy_translation_speed * object_depth * (x - self.x_last)
+            ty = self.xy_translation_speed * object_depth * (y - self.y_last)
 
-            self.object_center -= self.camera.extrinsic[0,:3] * tx + self.camera.extrinsic[1,:3] * ty
+            self.object_center -= (
+                self.camera.extrinsic[0, :3] * tx + self.camera.extrinsic[1, :3] * ty
+            )
             self.camera.extrinsic[0, 3] += tx
             self.camera.extrinsic[1, 3] += ty
-            center_in_camera= self.camera.world_to_camera(self.object_center)            
+            center_in_camera = self.camera.world_to_camera(self.object_center)
             self.x_last = x
             self.y_last = y
             assert np.max(np.abs(center_in_camera[:2])) < 1e-3
@@ -159,9 +155,8 @@ def mesh_viewer(
     display_fps=True,
     title=None,
     use_moderngl=False,
-    light_directional=(-0.5, 0, -0.5), 
-    light_ambient=0.3
-    
+    light_directional=(-0.5, 0, -0.5),
+    light_ambient=0.3,
 ):
     if type(obj_file_or_trimesh) == str:
         if title is None:
@@ -206,7 +201,9 @@ def mesh_viewer(
     )
 
     scene = differentiable_renderer.Scene3D()
-    scene.set_light(light_directional=np.array(light_directional), light_ambient=light_ambient)
+    scene.set_light(
+        light_directional=np.array(light_directional), light_ambient=light_ambient
+    )
     scene.set_mesh(mesh)
     background_image = np.ones((height, width, 3))
     scene.set_background(background_image)

--- a/deodr/examples/render_mesh.py
+++ b/deodr/examples/render_mesh.py
@@ -133,8 +133,9 @@ def example_moderngl(display=True, width=640, height=480):
     camera.extrinsic[1, 1] = camera.extrinsic[1, 1] * 0.9
 
     image_no_antialiasing = scene.render(camera)
-    moderngl_renderer = deodr.opengl.moderngl.OffscreenRenderer(znear=0.1, zfar=1000)
-    image_moderngl = moderngl_renderer.render(scene, camera)
+    moderngl_renderer = deodr.opengl.moderngl.OffscreenRenderer()
+    moderngl_renderer.set_scene(scene)
+    image_moderngl = moderngl_renderer.render(camera)
     diff = np.abs(
         image_no_antialiasing.astype(np.float) * 255 - image_moderngl.astype(np.float)
     )

--- a/deodr/mesh_fitter.py
+++ b/deodr/mesh_fitter.py
@@ -107,8 +107,6 @@ class MeshDepthFitter:
         self.mesh.set_vertices(vertices_transformed)
         self.depth_not_cliped = self.scene.render_depth(
             self.camera,
-            width=self.width,
-            height=self.height,
             depth_scale=self.depthScale,
         )
         depth = np.clip(self.depth_not_cliped, 0, self.scene.max_depth)

--- a/deodr/opengl/moderngl.py
+++ b/deodr/opengl/moderngl.py
@@ -44,10 +44,9 @@ def opencv_to_opengl_perspective(camera, znear, zfar):
 class OffscreenRenderer:
     """Class to perform offscreen rendering of deodr scenes using moderngl."""
 
-    def __init__(self, znear=None, zfar=None):
+    def __init__(self):
         self.ctx = moderngl.create_standalone_context()
-        self.znear = znear
-        self.zfar = zfar
+
         # Shaders
         self.shader_program = self.ctx.program(
             vertex_shader=opengl_shaders.vertex_shader_source,
@@ -56,10 +55,9 @@ class OffscreenRenderer:
         self.fbo = None
         self.texture = None
 
-    def render(self, deodr_scene, camera, znear=None, zfar=None):
-        ctx = self.ctx
-        shader_program = self.shader_program
-        bg_color = deodr_scene.background[0, 0]
+    def set_scene(self, deodr_scene):
+
+        self.bg_color = deodr_scene.background[0, 0]
         if False and not (np.all(deodr_scene.background == bg_color[None, None, :])):
             raise (
                 BaseException(
@@ -68,85 +66,90 @@ class OffscreenRenderer:
                 )
             )
 
-        if znear is None:
-            if self.znear is None:
-                raise BaseException(
-                    "OffscreenRenderer: you need to provide a znear value either in the constructor or when calling render"
-                )
-            znear = self.znear
+        self.shader_program["light_directional"].value = tuple(deodr_scene.light_directional)
+        self.shader_program["light_ambient"].value = deodr_scene.light_ambient
 
-        if zfar is None:
-            if self.zfar is None:
-                raise BaseException(
-                    "OffscreenRenderer: you need to provide a zfar value either in the constructor or when calling render"
-                )
-            zfar = self.zfar
 
-        # Setting up camera
+        self.set_mesh(deodr_scene.mesh)
 
-        extrinsic = np.row_stack((camera.extrinsic, [0, 0, 0, 1]))
+    def set_mesh(self, mesh):
 
-        intrinsic = Matrix44(
-            np.diag([1, -1, -1, 1]).dot(
-                opencv_to_opengl_perspective(camera, znear, zfar)
-            )
-        )
-        intrinsic
+        self.set_texture(mesh.texture)
+        # create triangles soup
 
-        #
-        shader_program["light_directional"].value = tuple(deodr_scene.light_directional)
-        shader_program["light_ambient"].value = deodr_scene.light_ambient
-        shader_program["intrinsic"].write(intrinsic.astype("f4").tobytes())
-        shader_program["extrinsic"].write(extrinsic.T.astype("f4").tobytes())
-        if camera.distortion is None:
-            k1, k2, p1, p2, k3 = (0, 0, 0, 0, 0)
-        else:
-            k1, k2, p1, p2, k3, = camera.distortion
-        shader_program["k1"].value = k1
-        shader_program["k2"].value = k2
-        shader_program["k3"].value = k3
-        shader_program["p1"].value = p1
-        shader_program["p2"].value = p2
-
-        # Texture
-        assert not deodr_scene.mesh.texture.flags["WRITEABLE"]
-        texture_id = id(deodr_scene.mesh.texture)
-        if self.texture is None or self.texture_id != texture_id:
-            self.texture_id = id(deodr_scene.mesh.texture)
-            self.texture = ctx.texture(
-                (deodr_scene.mesh.texture.shape[0], deodr_scene.mesh.texture.shape[1]),
-                deodr_scene.mesh.texture.shape[2],
-                (deodr_scene.mesh.texture * 255).astype(np.uint8).tobytes(),
-            )
-        # texture.build_mipmaps()
-
-        # compputing the box around the displaced mesh to get maximum accuracy
-        # of the xyz point cloud using unit8 opengl type
-
-        # creat triangles soup
-        mesh = deodr_scene.mesh
         vertices = mesh.vertices[mesh.faces].reshape(-1, 3)
+        min_max = np.stack((vertices.min(axis=0),vertices.max(axis=0)))
+        self.bounding_box_corners = np.stack(np.meshgrid(min_max[:,0],min_max[:,1],min_max[:,2]),axis=-1).reshape(-1,3)
         normals = mesh.vertex_normals[mesh.faces].reshape(-1, 3)
         uv = mesh.uv[mesh.faces_uv].reshape(-1, 2)
         moderngl_uv = np.column_stack(
             (
-                (uv[:, 0] + 0.5) / mesh.texture.shape[0],
-                ((uv[:, 1] + 0.5) / mesh.texture.shape[1]),
+                (uv[:, 0] + 0.5) / mesh.texture.shape[1],
+                ((uv[:, 1] + 0.5) / mesh.texture.shape[0]),
             )
         )
 
-        vbo_vert = ctx.buffer(vertices.astype("f4").tobytes())
-        vbo_norm = ctx.buffer(normals.astype("f4").tobytes())
-        vbo_uv = ctx.buffer(moderngl_uv.astype("f4").tobytes())
+        vbo_vert = self.ctx.buffer(vertices.astype("f4").tobytes())
+        vbo_norm = self.ctx.buffer(normals.astype("f4").tobytes())
+        vbo_uv = self.ctx.buffer(moderngl_uv.astype("f4").tobytes())
 
-        vao = ctx.vertex_array(
-            shader_program,
+        self.vao = self.ctx.vertex_array(
+            self.shader_program,
             [
                 (vbo_vert, "3f", "in_vert"),
                 (vbo_norm, "3f", "in_norm"),
                 (vbo_uv, "2f", "in_text"),
             ],
         )
+
+    def set_texture(self, texture):
+        # Texture
+        assert not texture.flags["WRITEABLE"]
+        texture_id = id(texture)
+        if self.texture is None or self.texture_id != texture_id:
+            self.texture_id = id(texture)
+            self.texture = self.ctx.texture(
+                (texture.shape[1], texture.shape[0]),
+                 texture.shape[2],
+                (texture * 255).astype(np.uint8).tobytes(),
+            )
+        # texture.build_mipmaps()
+
+    def set_camera(self, camera):
+        extrinsic = np.row_stack((camera.extrinsic, [0, 0, 0, 1]))
+
+
+        intrinsic = Matrix44(
+            np.diag([1, -1, -1, 1]).dot(
+                opencv_to_opengl_perspective(camera, self.znear, self.zfar)
+            )
+        )
+
+        #
+
+        self.shader_program["intrinsic"].write(intrinsic.astype("f4").tobytes())
+        self.shader_program["extrinsic"].write(extrinsic.T.astype("f4").tobytes())
+        if camera.distortion is None:
+            k1, k2, p1, p2, k3 = (0, 0, 0, 0, 0)
+        else:
+            k1, k2, p1, p2, k3, = camera.distortion
+        self.shader_program["k1"].value = k1
+        self.shader_program["k2"].value = k2
+        self.shader_program["k3"].value = k3
+        self.shader_program["p1"].value = p1
+        self.shader_program["p2"].value = p2
+
+    def render(self, camera):
+        ctx = self.ctx
+        self.zfar = camera.world_to_camera(self.bounding_box_corners)[:,2].max()        
+        self.znear = 1e-3* self.zfar
+        # Setting up camera
+        self.set_camera(camera)
+
+
+
+        # compputing the box around the displaced mesh to get maximum accuracy
+        # of the xyz point cloud using unit8 opengl type
 
         # Framebuffers
         if self.fbo is None:
@@ -158,9 +161,9 @@ class OffscreenRenderer:
         # Rendering the RGB image
         self.fbo.use()
         ctx.enable(moderngl.DEPTH_TEST)
-        ctx.clear(bg_color[0], bg_color[1], bg_color[2])
+        ctx.clear(self.bg_color[0], self.bg_color[1], self.bg_color[2])
         self.texture.use()
-        vao.render()
+        self.vao.render()
         data = self.fbo.read(components=3, alignment=1)
         array_rgb = np.frombuffer(data, dtype=np.uint8).reshape(
             camera.height, camera.width, 3

--- a/deodr/opengl/moderngl.py
+++ b/deodr/opengl/moderngl.py
@@ -58,7 +58,7 @@ class OffscreenRenderer:
     def set_scene(self, deodr_scene):
 
         self.bg_color = deodr_scene.background[0, 0]
-        if False and not (np.all(deodr_scene.background == bg_color[None, None, :])):
+        if False and not (np.all(deodr_scene.background == self.bg_color[None, None, :])):
             raise (
                 BaseException(
                     "does not support background image yet, please provide a backround\
@@ -66,9 +66,10 @@ class OffscreenRenderer:
                 )
             )
 
-        self.shader_program["light_directional"].value = tuple(deodr_scene.light_directional)
+        self.shader_program["light_directional"].value = tuple(
+            deodr_scene.light_directional
+        )
         self.shader_program["light_ambient"].value = deodr_scene.light_ambient
-
 
         self.set_mesh(deodr_scene.mesh)
 
@@ -78,8 +79,10 @@ class OffscreenRenderer:
         # create triangles soup
 
         vertices = mesh.vertices[mesh.faces].reshape(-1, 3)
-        min_max = np.stack((vertices.min(axis=0),vertices.max(axis=0)))
-        self.bounding_box_corners = np.stack(np.meshgrid(min_max[:,0],min_max[:,1],min_max[:,2]),axis=-1).reshape(-1,3)
+        min_max = np.stack((vertices.min(axis=0), vertices.max(axis=0)))
+        self.bounding_box_corners = np.stack(
+            np.meshgrid(min_max[:, 0], min_max[:, 1], min_max[:, 2]), axis=-1
+        ).reshape(-1, 3)
         normals = mesh.vertex_normals[mesh.faces].reshape(-1, 3)
         uv = mesh.uv[mesh.faces_uv].reshape(-1, 2)
         moderngl_uv = np.column_stack(
@@ -110,14 +113,13 @@ class OffscreenRenderer:
             self.texture_id = id(texture)
             self.texture = self.ctx.texture(
                 (texture.shape[1], texture.shape[0]),
-                 texture.shape[2],
+                texture.shape[2],
                 (texture * 255).astype(np.uint8).tobytes(),
             )
         # texture.build_mipmaps()
 
     def set_camera(self, camera):
         extrinsic = np.row_stack((camera.extrinsic, [0, 0, 0, 1]))
-
 
         intrinsic = Matrix44(
             np.diag([1, -1, -1, 1]).dot(
@@ -141,12 +143,10 @@ class OffscreenRenderer:
 
     def render(self, camera):
         ctx = self.ctx
-        self.zfar = camera.world_to_camera(self.bounding_box_corners)[:,2].max()        
-        self.znear = 1e-3* self.zfar
+        self.zfar = camera.world_to_camera(self.bounding_box_corners)[:, 2].max()
+        self.znear = 1e-3 * self.zfar
         # Setting up camera
         self.set_camera(camera)
-
-
 
         # compputing the box around the displaced mesh to get maximum accuracy
         # of the xyz point cloud using unit8 opengl type

--- a/deodr/pytorch/mesh_fitter_pytorch.py
+++ b/deodr/pytorch/mesh_fitter_pytorch.py
@@ -275,7 +275,7 @@ class MeshDepthFitter:
 
         depth_scale = 1 * self.depthScale
         depth = self.scene.render_depth(
-            self.camera, width=self.width, height=self.height, depth_scale=depth_scale
+            self.camera, depth_scale=depth_scale
         )
         depth = torch.clamp(depth, 0, self.scene.max_depth)
 

--- a/deodr/tensorflow/mesh_fitter_tensorflow.py
+++ b/deodr/tensorflow/mesh_fitter_tensorflow.py
@@ -144,8 +144,6 @@ class MeshDepthFitter:
             depth_scale = 1 * self.depthScale
             depth = self.scene.render_depth(
                 self.camera,
-                width=self.width,
-                height=self.height,
                 depth_scale=depth_scale,
             )
             depth = tf.clip_by_value(depth, 0, self.scene.max_depth)

--- a/deodr/triangulated_mesh.py
+++ b/deodr/triangulated_mesh.py
@@ -165,7 +165,8 @@ class TriMesh:
         self.face_normals = None
         self.vertex_normals = None
         self.clockwise = clockwise
-        self.set_vertices(vertices)
+        if vertices is not None:
+            self.set_vertices(vertices)
         if compute_adjacencies:
             self.compute_adjacencies()
 

--- a/deodr/triangulated_mesh.py
+++ b/deodr/triangulated_mesh.py
@@ -82,8 +82,10 @@ class TriMeshAdjacencies:
         assert np.all(self.Laplacian * np.ones((self.nb_vertices)) == 0)
         self.store_backward = {}
 
-    def boundary_edges():
-        is_boundary_edge = np.array(np.sum(submesh.adjacencies.edges_faces_ones, axis=1) == 1).squeeze(axis=1)
+    def boundary_edges(self):
+        is_boundary_edge = np.array(
+            np.sum(self.adjacencies.edges_faces_ones, axis=1) == 1
+        ).squeeze(axis=1)
         return self.edges[is_boundary_edge, :]
 
     def id_edge(self, idv):
@@ -150,11 +152,11 @@ class TriMesh:
 
     def __init__(self, faces, vertices=None, clockwise=False, compute_adjacencies=True):
 
-        assert(np.issubdtype(faces.dtype, np.integer))
+        assert np.issubdtype(faces.dtype, np.integer)
         assert faces.ndim == 2
         assert faces.shape[1] == 3
         assert np.all(faces >= 0)
-        
+
         self.faces = faces
         self.nb_vertices = np.max(faces) + 1
         self.nb_faces = faces.shape[0]
@@ -169,7 +171,7 @@ class TriMesh:
 
     def compute_adjacencies(self):
         self.adjacencies = TriMeshAdjacencies(self.faces, self.clockwise)
-        
+
         if self.vertices is not None:
 
             if self.adjacencies.is_closed:
@@ -304,7 +306,7 @@ class ColoredTriMesh(TriMesh):
 
         # Process vertex colors
         if mesh.visual.kind == "vertex":
-            colors = mesh.visual.vertex_colors.copy()[:,:3]
+            colors = mesh.visual.vertex_colors.copy()[:, :3]
 
         # Process face colors
         elif mesh.visual.kind == "face":
@@ -343,7 +345,7 @@ class ColoredTriMesh(TriMesh):
         )
         faces = inv_ids[mesh.faces].astype(np.uint32)
         if colors is not None:
-            colors2 = colors[return_index,:]
+            colors2 = colors[return_index, :]
             if np.any(colors != colors2[inv_ids, :]):
                 raise (
                     BaseException(
@@ -397,8 +399,8 @@ class ColoredTriMesh(TriMesh):
         uv = vt[mask_vt].copy()
 
         texture_uint8 = np.clip(self.texture * 255, 0, 255).astype(np.uint8)
-        if texture_uint8.shape[2]==1:
-            texture_uint8=texture_uint8.squeeze(axis=2)
+        if texture_uint8.shape[2] == 1:
+            texture_uint8 = texture_uint8.squeeze(axis=2)
         texture_pil = PIL.Image.fromarray(texture_uint8)
         material = trimesh.visual.material.SimpleMaterial(image=texture_pil)
         visual = trimesh.visual.texture.TextureVisuals(uv=uv, material=material)


### PR DESCRIPTION
BUG FIX
- fixing some bug when the texture is not square.

IMPROVEMENTS
- improving opengl viewer example with ctrl+left click to translate the mesh
- the opengl renderer as now a seperated method to add the scene , to avoid recreating the opengl mesh at each frame and keep the framerate high when using large meshes.
- znear and zfar for opengl camera computed automatically from the mesh bounding box and camera position

 API CHANGE 
- removing unnecessary argument from render_depth as already provided through the camera argument
- the opengl renderer as now a seperated method to add the scene
