### PR TITLE
Robust x range

### DIFF
--- a/C++/DifferentiableRenderer.h
+++ b/C++/DifferentiableRenderer.h
@@ -44,10 +44,10 @@ using namespace std;
 
 
 void get_edge_xrange_from_ineq(double ineq[12], int width, int y, int &x_begin, int &x_end);
-inline void render_part_interpolated(double* image, double* z_buffer, int y_begin, int y_end, bool strict_edge, double* xy1_to_A, double* xy1_to_Z, double* left_eq, double* right_eq, int width, int height, int sizeA, bool perspective_correct);
-inline void render_part_interpolated_B(double* image, double* image_B, double* z_buffer, int y_begin, int y_end, bool strict_edge,double* xy1_to_A, double* xy1_to_A_B, double* xy1_to_Z, double* left_eq, double* right_eq, int width, int height, int sizeA, bool perspective_correct);
-inline  void render_part_textured_gouraud(double* image, double* z_buffer, int y_begin, int y_end, bool strict_edge,double* xy1_to_UV, double* xy1_to_L, double* xy1_to_Z, double* left_eq, double* right_eq, int width, int height, int sizeA, double* Texture, int* Texture_size, bool perspective_correct);
-inline  void render_part_textured_gouraud_B(double* image, double* image_B, double* z_buffer, int y_begin, int y_end, bool strict_edge, double* xy1_to_UV, double* xy1_to_UV_B, double* xy1_to_L, double* xy1_to_L_B, double* xy1_to_Z, double* left_eq, double* right_eq, int width, int height, int sizeA, double* Texture, double* Texture_B, int* Texture_size, bool perspective_correct);
+inline void render_part_interpolated(double* image, double* z_buffer, int y_begin,  int x_min, int x_max, int y_end, bool strict_edge, double* xy1_to_A, double* xy1_to_Z, double* left_eq, double* right_eq, int width, int height, int sizeA, bool perspective_correct);
+inline void render_part_interpolated_B(double* image, double* image_B, double* z_buffer, int x_min, int x_max, int y_begin, int y_end, bool strict_edge,double* xy1_to_A, double* xy1_to_A_B, double* xy1_to_Z, double* left_eq, double* right_eq, int width, int height, int sizeA, bool perspective_correct);
+inline  void render_part_textured_gouraud(double* image, double* z_buffer, int x_min, int x_max, int y_begin, int y_end, bool strict_edge,double* xy1_to_UV, double* xy1_to_L, double* xy1_to_Z, double* left_eq, double* right_eq, int width, int height, int sizeA, double* Texture, int* Texture_size, bool perspective_correct);
+inline  void render_part_textured_gouraud_B(double* image, double* image_B, double* z_buffer, int x_min, int x_max, int y_begin, int y_end, bool strict_edge, double* xy1_to_UV, double* xy1_to_UV_B, double* xy1_to_L, double* xy1_to_L_B, double* xy1_to_Z, double* left_eq, double* right_eq, int width, int height, int sizeA, double* Texture, double* Texture_B, int* Texture_size, bool perspective_correct);
 
 struct Scene {
 	unsigned int* faces;
@@ -366,10 +366,13 @@ inline void dot_prod_B(const double R_B, double V1_B[3], const double V2[3])
 		V1_B[i] += R_B * V2[i];
 }
 
-inline void Edge_equ(double e[2], const double v1[2], const double v2[2])
-{
-	e[0] = (v1[0] - v2[0]) / (v1[1] - v2[1]);
-	e[1] = v1[0] - e[0] * v1[1];
+
+inline void Edge_equ3(double e[3], const double v1[2], const double v2[2])
+{   
+	// compute edges equations of type ax+by+c = 0
+	e[0] = (v2[1] - v1[1]);
+	e[1] = (v1[0] - v2[0]);
+	e[2] = - 0.5 * ( e[0] * (v1[0] + v2[0]) + e[1] * (v1[1] + v2[1]));
 }
 
 inline void sort3(const double v[3], double sv[3], short int i[3])
@@ -381,9 +384,9 @@ inline void sort3(const double v[3], double sv[3], short int i[3])
 	short int tmp2;
 	for (int k = 0; k < 3; k++) sv[k] = v[k];
 	for (int k = 0; k < 3; k++) i[k] = k;
-	if (sv[0] > sv[1]) { SWAP(sv[0], sv[1], tmp1); SWAP(i[0], i[1], tmp2); }
-	if (sv[0] > sv[2]) { SWAP(sv[0], sv[2], tmp1); SWAP(i[0], i[2], tmp2); }
-	if (sv[1] > sv[2]) { SWAP(sv[1], sv[2], tmp1); SWAP(i[1], i[2], tmp2); }
+	if (sv[0] > sv[1]) { SWAP(sv[0], sv[1], tmp1); SWAP(i[0], i[1], tmp2);}
+	if (sv[0] > sv[2]) { SWAP(sv[0], sv[2], tmp1); SWAP(i[0], i[2], tmp2);}
+	if (sv[1] > sv[2]) { SWAP(sv[1], sv[2], tmp1); SWAP(i[1], i[2], tmp2);}
 }
 
 inline void elementwise_inverse_vec3(const double input[3], double ouput[3])
@@ -398,6 +401,90 @@ inline void elementwise_prod_vec3(const double input1[3], const double input2[3]
 		ouput[i] = input1[i] * input2[i];
 }
 
+
+short int floor_div(double a, double b, int x_min, int x_max)
+{
+
+	// robust implementation of min ( x_max, max (x_min, floor(a / b)))
+
+	short int x;
+
+	double max_div = 100000;
+	
+	if (abs(b) * max_div > abs(a))
+	{ 
+		double xf = floor(a / b);
+		if (xf < x_min)
+		{
+			xf = x_min;
+		}
+		if (xf > x_max)
+		{
+			xf = x_max;
+		}
+		x = (short int) xf;
+	}
+	else
+	{
+		if (b > 0)
+		{
+			x = x_min;
+			while (((x + 1) * b <= a) && (x < x_max))
+			{
+				x++;
+			}
+		}
+		else
+		{
+			x = x_min;
+			while (((x + 1) * b >= a) && (x < x_max))
+			{
+				x++;
+			}
+		}
+	}
+	return short int (x);
+}
+
+short int ceil_div(double a, double b, int x_min, int x_max)
+{
+	// robust implementation of min ( x_max, max (x_min, ceil(a / b)))
+
+	short int x;
+	double max_short_int = 10000000;
+	if (true)//(abs(b) * max_short_int > abs(a))
+	{ 
+		x = (short int)ceil(a / b);
+		if (x < x_min)
+		{
+			x = x_min;
+		}
+		if (x > x_max)
+		{
+			x = x_max;
+		}
+	}
+	else
+	{
+		if (b > 0)
+		{
+			x = x_min;
+			while (((x + 1) * b < a) && (x < x_max))
+			{
+				x++;
+			}
+		}
+		else
+		{
+			x = x_min;
+			while (((x + 1) * b > a) && (x < x_max))
+			{
+				x++;
+			}
+		}
+	}
+	return x;
+}	
 
 template <class T> void bilinear_sample(T* A, T I[], int* I_size, double p[2], int sizeA)
 {
@@ -505,7 +592,7 @@ template <class T> void bilinear_sample_B(T* A, T* A_B, T I[], T I_B[], int* I_s
 	}
 }
 
-void get_triangle_stencil_equations(double Vxy[][2], double  bary_to_xy1[9], double  xy1_to_bary[9], double edge_eq[][2], bool strict_edge, int* y_begin, int* y_end, int* left_edge_id, int* right_edge_id)
+void get_triangle_stencil_equations(double Vxy[][2], double  bary_to_xy1[9], double  xy1_to_bary[9], double edge_eq[][3], bool strict_edge,  int &x_min, int &x_max, int* y_begin, int* y_end, int* left_edge_id, int* right_edge_id)
 {
 
 	// create a matrix that map barycentric coordinates to homogeneous image coordinates
@@ -527,27 +614,47 @@ void get_triangle_stencil_equations(double Vxy[][2], double  bary_to_xy1[9], dou
 
 	// compute edges equations of type x=ay+b
 
-	Edge_equ(edge_eq[0], Vxy[0], Vxy[1]);
-	Edge_equ(edge_eq[1], Vxy[1], Vxy[2]);
-	Edge_equ(edge_eq[2], Vxy[2], Vxy[0]);
+	Edge_equ3(edge_eq[0], Vxy[0], Vxy[1]);
+	Edge_equ3(edge_eq[1], Vxy[1], Vxy[2]);
+	Edge_equ3(edge_eq[2], Vxy[2], Vxy[0]);
 
 	// sort vertices w.r.t y direction 
-
+	double     x_unsorted[3];
 	double     y_unsorted[3];
+	short int  x_order[3];
 	short int  y_order[3];
+	double     x_sorted[3];
 	double     y_sorted[3];
+
+	for (int k = 0; k < 3; k++) x_unsorted[k] = Vxy[k][0];
+	sort3(x_unsorted, x_sorted, x_order);
 	for (int k = 0; k < 3; k++) y_unsorted[k] = Vxy[k][1];
 	sort3(y_unsorted, y_sorted, y_order);
 
+	// computing x bounds
+	if (strict_edge)
+	{
+		x_min = (short)floor(x_sorted[0]) + 1;
+	}
+	else
+	{
+		x_min = (short)ceil(x_sorted[0]);
+	}
+
+	x_max = (short)floor(x_sorted[2]);
+		
 	// limit upper part
 	if (strict_edge)
 	{
+		
 		y_begin[0] = (short)floor(y_sorted[0]) + 1;
 	}
 	else
 	{
+		
 		y_begin[0] = (short)ceil(y_sorted[0]);
-	}	
+	}
+	
 	y_end[0] = (short)floor(y_sorted[1]);
 	
 
@@ -566,7 +673,7 @@ void get_triangle_stencil_equations(double Vxy[][2], double  bary_to_xy1[9], dou
 
 	int id;
 	id = y_order[0];
-	if (edge_eq[(id) % 3][0] < edge_eq[(id + 2) % 3][0])
+	if (edge_eq[(id) % 3][0] > 0)
 	{
 		right_edge_id[0] = (id + 2) % 3;  left_edge_id[0] = (id) % 3;
 	}
@@ -575,18 +682,9 @@ void get_triangle_stencil_equations(double Vxy[][2], double  bary_to_xy1[9], dou
 		right_edge_id[0] = (id) % 3;  left_edge_id[0] = (id + 2) % 3;
 	}
 	
-	// deal with edge case of horizontal segment
-	if (isinf(edge_eq[right_edge_id[0]][0]))
-	{
-		right_edge_id[0]= (id + 1) % 3;
-	}
-	if (isinf(edge_eq[left_edge_id[0]][0]))
-	{
-		left_edge_id[0]= (id + 1) % 3;
-	}
 	
 	id = y_order[2];
-	if (edge_eq[(id) % 3][0] < edge_eq[(id + 2) % 3][0])
+	if (edge_eq[(id) % 3][0] < 0)
 	{
 		right_edge_id[1] = (id) % 3;  left_edge_id[1] = (id + 2) % 3;
 	}
@@ -595,32 +693,24 @@ void get_triangle_stencil_equations(double Vxy[][2], double  bary_to_xy1[9], dou
 		right_edge_id[1] = (id + 2) % 3;  left_edge_id[1] = (id) % 3;
 	}
 	
-	// deal with edge case of horizontal segment
-	if (isinf(edge_eq[right_edge_id[1]][0]))
-	{
-		right_edge_id[1]= (id + 1) % 3;
-	}
-	if (isinf(edge_eq[left_edge_id[1]][0]))
-	{
-		left_edge_id[1]= (id + 1) % 3;
-	}
 }
 
 template <class T> void rasterize_triangle_interpolated(double Vxy[][2], double Zvertex[3], T* Avertex[], double z_buffer[], T image[], int height, int width, int sizeA, bool strict_edge, bool perspective_correct)
 {
 	int     y_begin[2], y_end[2];
 
-	double  edge_eq[3][2];
+	double  edge_eq[3][3];
 	double  bary_to_xy1[9];
 	double  xy1_to_bary[9];
 	double* xy1_to_A;
 	double  xy1_to_Z[3];
 	int     left_edge_id[2], right_edge_id[2];
+	int x_min, x_max;
 	
 	//   compute triangle borders equations
 	//double Vxy[][2],double  bary_to_xy1[9],double  xy1_to_bary[9],double* edge_eq[3],y_begin,y_end,left_edge_id,right_edge_id)
 
-	get_triangle_stencil_equations(Vxy, bary_to_xy1, xy1_to_bary, edge_eq, strict_edge, y_begin, y_end, left_edge_id, right_edge_id);
+	get_triangle_stencil_equations(Vxy, bary_to_xy1, xy1_to_bary, edge_eq, strict_edge, x_min, x_max, y_begin, y_end, left_edge_id, right_edge_id);
 
 	// create matrices that map image coordinates to attributes A and depth z
 	xy1_to_A = new double[3 * sizeA];
@@ -652,7 +742,7 @@ template <class T> void rasterize_triangle_interpolated(double Vxy[][2], double 
 	}
 	for (int k = 0; k < 2; k++)
 	{
-		render_part_interpolated(image, z_buffer, y_begin[k], y_end[k], strict_edge, xy1_to_A, xy1_to_Z, edge_eq[left_edge_id[k]], edge_eq[right_edge_id[k]], width, height, sizeA , perspective_correct);
+		render_part_interpolated(image, z_buffer, x_min, x_max, y_begin[k], y_end[k], strict_edge, xy1_to_A, xy1_to_Z, edge_eq[left_edge_id[k]], edge_eq[right_edge_id[k]], width, height, sizeA , perspective_correct);
 	}
 	delete[] xy1_to_A;
 }
@@ -660,12 +750,13 @@ template <class T> void rasterize_triangle_interpolated(double Vxy[][2], double 
 template <class T> void rasterize_triangle_interpolated_B(double Vxy[][2], double Vxy_B[][2], double Zvertex[3], T* Avertex[], T* Avertex_B[], double z_buffer[], T image[], T image_B[], int height, int width, int sizeA, bool strict_edge, bool perspective_correct)
 {
 	int     y_begin[2], y_end[2];
-	double  edge_eq[3][2];
+	double  edge_eq[3][3];
 	double  bary_to_xy1[9];
 	double  xy1_to_bary[9];
 	double* xy1_to_A;
 	double  xy1_to_Z[3];
 	int     left_edge_id[2], right_edge_id[2];
+	int     x_min, x_max;
 
 	if (perspective_correct)
 	{
@@ -675,7 +766,7 @@ template <class T> void rasterize_triangle_interpolated_B(double Vxy[][2], doubl
 	//   compute triangle borders equations
 	//double Vxy[][2],double  bary_to_xy1[9],double  xy1_to_bary[9],double* edge_eq[3],y_begin,y_end,left_edge_id,right_edge_id)
 
-	get_triangle_stencil_equations(Vxy, bary_to_xy1, xy1_to_bary, edge_eq, strict_edge, y_begin, y_end, left_edge_id, right_edge_id);
+	get_triangle_stencil_equations(Vxy, bary_to_xy1, xy1_to_bary, edge_eq, strict_edge, x_min, x_max, y_begin, y_end, left_edge_id, right_edge_id);
 
 	// create matrices that map image coordinates to attributes A and depth z
 
@@ -693,7 +784,7 @@ template <class T> void rasterize_triangle_interpolated_B(double Vxy[][2], doubl
 	for (short int i = 0; i < 3 * sizeA; i++) xy1_to_A_B[i] = 0;
 	
 	for (int k = 0; k < 2; k++)
-		render_part_interpolated_B(image, image_B, z_buffer, y_begin[k], y_end[k], strict_edge, xy1_to_A, xy1_to_A_B, xy1_to_Z, edge_eq[left_edge_id[k]], edge_eq[right_edge_id[k]], width, height, sizeA, perspective_correct);
+		render_part_interpolated_B(image, image_B, z_buffer, x_min, x_max , y_begin[k], y_end[k], strict_edge, xy1_to_A, xy1_to_A_B, xy1_to_Z, edge_eq[left_edge_id[k]], edge_eq[right_edge_id[k]], width, height, sizeA, perspective_correct);
 
 
 	double  xy1_to_bary_B[9] = { 0 };
@@ -722,30 +813,53 @@ template <class T> void rasterize_triangle_interpolated_B(double Vxy[][2], doubl
 	delete[] xy1_to_A_B;
 }
 
-inline void get_xrange(int width, const double* left_eq, const double* right_eq, short int y, bool strict_edge, short int &x_begin, short int &x_end)
+inline void get_xrange(int width, const double* left_eq, const double* right_eq, short int y, bool strict_edge, short int x_min,short int x_max, short int &x_begin, short int &x_end)
 {
 	// compute beginning and ending of the rasterized line	
-	x_begin = 0;
-	short int temp_x;	
+
+	short int temp_x;
+
+	double numerator;
+	
+
+
+	if (x_min<0)
+	{ 
+		x_min = 0;
+	}
+	if (x_max > width - 1)
+	{
+		x_max = width - 1;
+	}
+
+	x_begin = x_min;
+	x_end = x_max;
+
+	numerator = -(left_eq[1] * y + left_eq[2]);
+
 	if (strict_edge)
-	{	
+	{
 		// pixels falling exactly on an edge shared by two triangle will be drawn only once 
 		// when rasterizing the the triangle on the left of the edge.
-		temp_x = 1 + (short int)floor(left_eq[0] * y + left_eq[1]);
+		temp_x = 1 + floor_div(numerator , left_eq[0], x_min-1, x_max);
+
 	}
 	else
-	{	
+	{
 		// pixels falling exactly on an edge shared by two triangle will be drawn twice
-		temp_x = (short int) ceil(left_eq[0] * y + left_eq[1]);
+		temp_x = ceil_div(numerator , left_eq[0], x_min-1, x_max);
 	}
 	if (temp_x > x_begin) x_begin = temp_x;
-
-	x_end = width - 1;
-	temp_x = (short int)floor(right_eq[0] * y + right_eq[1]);
+	
+	numerator = -(right_eq[1] * y + right_eq[2]);
+	temp_x = floor_div(numerator , right_eq[0], x_min-1, x_max);
 	if (temp_x < x_end) x_end = temp_x;
+		
+
+
 }
 
-inline void render_part_interpolated(double* image, double* z_buffer, int y_begin, int y_end, bool strict_edge, double* xy1_to_A, double* xy1_to_Z, double* left_eq, double* right_eq, int width, int height, int sizeA, bool perspective_correct)
+inline void render_part_interpolated(double* image, double* z_buffer, int x_min, int x_max, int y_begin, int y_end, bool strict_edge, double* xy1_to_A, double* xy1_to_Z, double* left_eq, double* right_eq, int width, int height, int sizeA, bool perspective_correct)
 {
 	double t[3];
 	double *A0y;
@@ -754,7 +868,14 @@ inline void render_part_interpolated(double* image, double* z_buffer, int y_begi
 	double Z;
 	A0y = new double[sizeA];
 
-	if (y_begin < 0)     y_begin = 0;  if (y_end > height - 1) y_end = height - 1;
+	if (y_begin < 0)
+	{
+		y_begin = 0;
+	}
+	if (y_end > height - 1)
+	{
+		y_end = height - 1;
+	}
 	for (short int y = y_begin; y <= y_end; y++)
 	{
 		// Line rasterization setup for interpolated values 
@@ -766,7 +887,7 @@ inline void render_part_interpolated(double* image, double* z_buffer, int y_begi
 
 		// compute beginning and ending of the rasterized line		
 
-		get_xrange(width, left_eq, right_eq, y, strict_edge, x_begin,x_end);
+		get_xrange(width, left_eq, right_eq, y, strict_edge, x_min, x_max, x_begin,x_end);
 
 		//rasterize line
 
@@ -802,7 +923,7 @@ inline void render_part_interpolated(double* image, double* z_buffer, int y_begi
 	delete[]A0y;
 }
 
-inline void render_part_interpolated_B(double* image, double* image_B, double* z_buffer, int y_begin, int y_end, bool strict_edge, double* xy1_to_A, double* xy1_to_A_B, double* xy1_to_Z, double* left_eq, double* right_eq, int width, int height, int sizeA, bool perspective_correct)
+inline void render_part_interpolated_B(double* image, double* image_B, double* z_buffer,int x_min, int x_max, int y_begin, int y_end, bool strict_edge, double* xy1_to_A, double* xy1_to_A_B, double* xy1_to_Z, double* left_eq, double* right_eq, int width, int height, int sizeA, bool perspective_correct)
 {
 	double t[3];
 	//double *A0y;
@@ -836,7 +957,7 @@ inline void render_part_interpolated_B(double* image, double* image_B, double* z
 
 		// compute beginning and ending of the rasterized line		
 
-		get_xrange(width, left_eq, right_eq, y, strict_edge, x_begin,x_end);
+		get_xrange(width, left_eq, right_eq, y, strict_edge, x_min, x_max, x_begin,x_end);
 
 		//rasterize line
 
@@ -867,17 +988,18 @@ template <class T> void rasterize_triangle_textured_gouraud(double Vxy[][2], dou
 {
 	int     y_begin[2], y_end[2];
 
-	double  edge_eq[3][2];
+	double  edge_eq[3][3];
 	double  bary_to_xy1[9];
 	double  xy1_to_bary[9];
 	double  xy1_to_UV[6];
 	double  xy1_to_L[3];
 	double  xy1_to_Z[3];
 	int     left_edge_id[2], right_edge_id[2];
+	int     x_min, x_max;
 	
 	//   compute triangle borders equations
 
-	get_triangle_stencil_equations(Vxy, bary_to_xy1, xy1_to_bary, edge_eq, strict_edge, y_begin, y_end, left_edge_id, right_edge_id);
+	get_triangle_stencil_equations(Vxy, bary_to_xy1, xy1_to_bary, edge_eq, strict_edge, x_min, x_max, y_begin, y_end, left_edge_id, right_edge_id);
 
 	// create matrices that map image coordinates to attributes A and depth z
 	if (perspective_correct)
@@ -910,13 +1032,13 @@ template <class T> void rasterize_triangle_textured_gouraud(double Vxy[][2], dou
 
 
 	for (int k = 0; k < 2; k++)
-		render_part_textured_gouraud(image, z_buffer, y_begin[k], y_end[k], strict_edge, xy1_to_UV, xy1_to_L, xy1_to_Z, edge_eq[left_edge_id[k]], edge_eq[right_edge_id[k]], width, height, sizeA, Texture, Texture_size, perspective_correct);
+		render_part_textured_gouraud(image, z_buffer, x_min, x_max, y_begin[k], y_end[k], strict_edge, xy1_to_UV, xy1_to_L, xy1_to_Z, edge_eq[left_edge_id[k]], edge_eq[right_edge_id[k]], width, height, sizeA, Texture, Texture_size, perspective_correct);
 }
 
 template <class T> void rasterize_triangle_textured_gouraud_B(double Vxy[][2], double Vxy_B[][2], double Zvertex[3], double UVvertex[][2], double UVvertex_B[][2], double ShadeVertex[], double ShadeVertex_B[], double z_buffer[], T image[], T image_B[], int height, int width, int sizeA, T* Texture, T* Texture_B, int* Texture_size, bool strict_edge, bool perspective_correct)
 {
 	int     y_begin[2], y_end[2];
-	double  edge_eq[3][2];
+	double  edge_eq[3][3];
 	double  bary_to_xy1[9];
 	double  bary_to_xy1_B[9] = { 0 };
 	double  xy1_to_bary[9];
@@ -927,6 +1049,7 @@ template <class T> void rasterize_triangle_textured_gouraud_B(double Vxy[][2], d
 	double  xy1_to_UV_B[6] = { 0 };
 	double  xy1_to_L_B[3] = { 0 };
 	double  xy1_to_Z_B[3] = { 0 };
+	int     x_min, x_max;
 
 	int     left_edge_id[2], right_edge_id[2];
 	
@@ -937,7 +1060,7 @@ template <class T> void rasterize_triangle_textured_gouraud_B(double Vxy[][2], d
 	
 	//   compute triangle borders equations
 
-	get_triangle_stencil_equations(Vxy, bary_to_xy1, xy1_to_bary, edge_eq, strict_edge, y_begin, y_end, left_edge_id, right_edge_id);
+	get_triangle_stencil_equations(Vxy, bary_to_xy1, xy1_to_bary, edge_eq, strict_edge, x_min, x_max, y_begin, y_end, left_edge_id, right_edge_id);
 
 	// create matrices that map image coordinates to attributes A and depth z
 
@@ -952,7 +1075,7 @@ template <class T> void rasterize_triangle_textured_gouraud_B(double Vxy[][2], d
 		}
 
 	for (int k = 0; k < 2; k++)
-		render_part_textured_gouraud_B(image, image_B, z_buffer, y_begin[k], y_end[k], strict_edge, xy1_to_UV, xy1_to_UV_B, xy1_to_L, xy1_to_L_B, xy1_to_Z, edge_eq[left_edge_id[k]], edge_eq[right_edge_id[k]], width, height, sizeA, Texture, Texture_B, Texture_size, perspective_correct);
+		render_part_textured_gouraud_B(image, image_B, z_buffer, x_min, x_max,  y_begin[k], y_end[k], strict_edge, xy1_to_UV, xy1_to_UV_B, xy1_to_L, xy1_to_L_B, xy1_to_Z, edge_eq[left_edge_id[k]], edge_eq[right_edge_id[k]], width, height, sizeA, Texture, Texture_B, Texture_size, perspective_correct);
 
 	for (short int i = 0; i < 2; i++)
 		for (short int j = 0; j < 3; j++)
@@ -975,7 +1098,7 @@ template <class T> void rasterize_triangle_textured_gouraud_B(double Vxy[][2], d
 			Vxy_B[v][d] += bary_to_xy1_B[3 * d + v];
 }
 
-inline  void render_part_textured_gouraud(double* image, double* z_buffer, int y_begin, int y_end, bool strict_edge, double* xy1_to_UV, double* xy1_to_L, double* xy1_to_Z, double* left_eq, double* right_eq, int width, int height, int sizeA, double* Texture, int* Texture_size, bool perspective_correct)
+inline  void render_part_textured_gouraud(double* image, double* z_buffer, int x_min, int x_max, int y_begin, int y_end, bool strict_edge, double* xy1_to_UV, double* xy1_to_L, double* xy1_to_Z, double* left_eq, double* right_eq, int width, int height, int sizeA, double* Texture, int* Texture_size, bool perspective_correct)
 {
 	double t[3];
 	double L0y;
@@ -1007,7 +1130,7 @@ inline  void render_part_textured_gouraud(double* image, double* z_buffer, int y
 
 		// compute beginning and ending of the rasterized line		
 
-		get_xrange(width, left_eq, right_eq, y, strict_edge, x_begin,x_end);
+		get_xrange(width, left_eq, right_eq, y, strict_edge, x_min, x_max, x_begin,x_end);
 
 		// line rasterization
 
@@ -1066,7 +1189,7 @@ inline  void render_part_textured_gouraud(double* image, double* z_buffer, int y
 	delete[]A;
 }
 
-inline  void render_part_textured_gouraud_B(double* image, double* image_B, double* z_buffer, int y_begin, int y_end, bool strict_edge, double* xy1_to_UV, double* xy1_to_UV_B, double* xy1_to_L, double* xy1_to_L_B, double* xy1_to_Z, double* left_eq, double* right_eq, int width, int height, int sizeA, double* Texture, double* Texture_B, int* Texture_size, bool perspective_correct)
+inline  void render_part_textured_gouraud_B(double* image, double* image_B, double* z_buffer, int x_min, int x_max, int y_begin, int y_end, bool strict_edge, double* xy1_to_UV, double* xy1_to_UV_B, double* xy1_to_L, double* xy1_to_L_B, double* xy1_to_Z, double* left_eq, double* right_eq, int width, int height, int sizeA, double* Texture, double* Texture_B, int* Texture_size, bool perspective_correct)
 {
 	double t[3];
 	double L0y;
@@ -1109,7 +1232,7 @@ inline  void render_part_textured_gouraud_B(double* image, double* image_B, doub
 
 		// compute beginning and ending of the rasterized line		
 
-		get_xrange(width, left_eq, right_eq, y, strict_edge, x_begin,x_end);
+		get_xrange(width, left_eq, right_eq, y, strict_edge, x_min, x_max, x_begin,x_end);
 
 		// line rasterization
 
@@ -1223,19 +1346,19 @@ void get_edge_stencil_equations(double Vxy[][2], int height, int width, double s
 	for (short int k = 0; k < 2; k++)
 		for (short int j = 0; j < 3; j++)
 		{
-			ineq[3 * k + j] = xy1_to_bary[3 * k + j] / fabs(B_inc[k]);
+			ineq[3 * k + j] = xy1_to_bary[3 * k + j];
 		}
 
 	for (short int j = 0; j < 3; j++)
 	{
-		ineq[3 * 2 + j] = xy1_to_transp[j] / fabs(T_inc);
+		ineq[3 * 2 + j] = xy1_to_transp[j];
 	}
 
 	for (short int j = 0; j < 2; j++)
 	{
-		ineq[3 * 3 + j] = -xy1_to_transp[j] / fabs(T_inc);
+		ineq[3 * 3 + j] = -xy1_to_transp[j];
 	}
-	ineq[3 * 3 + 2] = (1 - xy1_to_transp[2]) / fabs(T_inc);
+	ineq[3 * 3 + 2] = (1 - xy1_to_transp[2]);
 
 	// y limits
 
@@ -2385,17 +2508,18 @@ void get_edge_xrange_from_ineq(double ineq[12], int width, int y, int &x_begin, 
 
 	x_begin = 0;
 	x_end = width - 1;
-
+	double numerator;
 	for (short int k = 0; k < 4; k++)
 	{
+		numerator = -(ineq[3 * k + 1] * y + ineq[3 * k + 2]);
 		if (ineq[3 * k] < 0)
 		{
-			temp_x = (short int)floor(ineq[3 * k + 1] * y + ineq[3 * k + 2]);
+			temp_x = floor_div(numerator , ineq[3 * k], x_begin-1,x_end+1);
 			if (temp_x < x_end) { x_end = temp_x; }
 		}
 		else
 		{
-			temp_x = 1 + (short int)floor(-ineq[3 * k + 1] * y - ineq[3 * k + 2]);
+			temp_x = 1 + floor_div(numerator , ineq[3 * k],x_begin-1,x_end+1);
 			if (temp_x > x_begin) { x_begin = temp_x; }
 		}
 	}

--- a/C++/DifferentiableRenderer.h
+++ b/C++/DifferentiableRenderer.h
@@ -153,7 +153,7 @@ void  inv_matrix_3x3_B(double* S, double* S_B, double* T, double* T_B)
 		inv_det_b += Tp[k] * T_B[k];
 		Tp_B[k] += inv_det * T_B[k];
 	}
-	double t = (S[0] * Tp[0] + S[1] * Tp[3] + S[2] * Tp[6]);
+	// double t = (S[0] * Tp[0] + S[1] * Tp[3] + S[2] * Tp[6]);
 	// double inv_det=1/t
 	double t_B = inv_det_b * (-inv_det * inv_det);//?
 
@@ -443,7 +443,7 @@ short int floor_div(double a, double b, int x_min, int x_max)
 			}
 		}
 	}
-	return short int (x);
+	return x;
 }
 
 short int ceil_div(double a, double b, int x_min, int x_max)
@@ -941,7 +941,14 @@ inline void render_part_interpolated_B(double* image, double* image_B, double* z
 	//A0y  =new double[sizeA];
 	A0y_B = new double[sizeA];
 
-	if (y_begin < 0)     y_begin = 0;  if (y_end > height - 1) y_end = height - 1;
+	if (y_begin < 0)
+	{
+		y_begin = 0;
+	}
+	if (y_end > height - 1)
+	{
+		y_end = height - 1;
+	}
 
 	for (short int y = y_begin; y <= y_end; y++)
 	{
@@ -1110,7 +1117,14 @@ inline  void render_part_textured_gouraud(double* image, double* z_buffer, int x
 
 	A = new double[sizeA];
 
-	if (y_begin < 0)     y_begin = 0;  if (y_end > height - 1) y_end = height - 1;
+	if (y_begin < 0)
+	{ 
+		y_begin = 0;
+	}
+	if (y_end > height - 1)
+	{
+		y_end = height - 1;
+	}
 
 	for (short int y = y_begin; y <= y_end; y++)
 	{
@@ -1210,7 +1224,14 @@ inline  void render_part_textured_gouraud_B(double* image, double* image_B, doub
 		throw "backward gradient propagation not supported yet with perspective_correct=True";		
 	}
 
-	if (y_begin < 0)     y_begin = 0;  if (y_end > height - 1) y_end = height - 1;
+	if (y_begin < 0)
+	{
+		y_begin = 0;
+	}
+	if (y_end > height - 1)
+	{ 
+		y_end = height - 1;
+	}
 
 	for (short int y = y_begin; y <= y_end; y++)
 	{
@@ -1333,13 +1354,6 @@ void get_edge_stencil_equations(double Vxy[][2], int height, int width, double s
 
 	for (int k = 0; k < 3; k++) { xy1_to_transp[k] = (1 / sigma)*xy1_to_edge[6 + k]; }
 
-	// compute edges equations j = dj_di * i + j0
-
-	double B_inc[2];
-	for (short int k = 0; k < 2; k++)
-		B_inc[k] = xy1_to_bary[3 * k];
-
-	double T_inc = xy1_to_transp[0];
 
 	// setup border inequalities e*[i,j,1]>0 -> inside the paralellogram 
 
@@ -2394,8 +2408,6 @@ template <class T> void rasterize_edge_interpolated_error_B(double Vxy[][2], dou
 	double T_inc_B = 0;
 
 	mul_matrix(1, 2, 3, xy1_to_Z, Zvertex, xy1_to_bary);
-
-	double  xy1_to_L_B[3] = { 0 };
 
 	for (short int i = 0; i < 3 * sizeA; i++) xy1_to_A_B[i] = 0;
 

--- a/C++/DifferentiableRenderer.h
+++ b/C++/DifferentiableRenderer.h
@@ -408,21 +408,18 @@ short int floor_div(double a, double b, int x_min, int x_max)
 	// robust implementation of min ( x_max, max (x_min, floor(a / b)))
 
 	short int x;
-
-	double max_div = 100000;
 	
-	if (abs(b) * max_div > abs(a))
+	if (abs(b) * SHRT_MAX > abs(a) + abs(b))
 	{ 
-		double xf = floor(a / b);
-		if (xf < x_min)
+		x = floor(a / b);
+		if (x < x_min)
 		{
-			xf = x_min;
+			x = x_min;
 		}
-		if (xf > x_max)
+		if (x > x_max)
 		{
-			xf = x_max;
+			x = x_max;
 		}
-		x = (short int) xf;
 	}
 	else
 	{
@@ -451,8 +448,8 @@ short int ceil_div(double a, double b, int x_min, int x_max)
 	// robust implementation of min ( x_max, max (x_min, ceil(a / b)))
 
 	short int x;
-	double max_short_int = 10000000;
-	if (true)//(abs(b) * max_short_int > abs(a))
+
+	if (abs(b) * SHRT_MAX > abs(a) + abs(b))
 	{ 
 		x = (short int)ceil(a / b);
 		if (x < x_min)

--- a/deodr/examples/rgb_multiview_hand.py
+++ b/deodr/examples/rgb_multiview_hand.py
@@ -20,8 +20,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
-def run(dl_library="pytorch", plot_curves=False, save_images=False, display=True):
+def run(dl_library="pytorch", plot_curves=False, save_images=False, display=True, max_iter=400):
 
+    file_folder = os.path.dirname(__file__)
     hand_images = [
         imread(file).astype(np.double) / 255
         for file in glob.glob(os.path.join(deodr.data_path, "./hand_multiview/*.jpg"))
@@ -62,7 +63,7 @@ def run(dl_library="pytorch", plot_curves=False, save_images=False, display=True
     # update_lights =  True, update_color= True,cregu=1000)
 
     hand_fitter.reset()
-    max_iter = 150
+
     hand_image = hand_images[0]
     background_color = np.median(
         np.row_stack(
@@ -82,12 +83,13 @@ def run(dl_library="pytorch", plot_curves=False, save_images=False, display=True
     durations = []
     start = time.time()
 
-    iterfolder = "./iterations/rgb_multiview"
+    iterfolder = os.path.join(file_folder, "./iterations/depth")
     if not os.path.exists(iterfolder):
         os.makedirs(iterfolder)
 
     for niter in range(max_iter):
-        energy, image, diff_image = hand_fitter.step()
+
+        energy, image, diff_image = hand_fitter.step(check_gradient=False)
         energies.append(energy)
         durations.append(time.time() - start)
         if display or save_images:

--- a/deodr/mesh_fitter.py
+++ b/deodr/mesh_fitter.py
@@ -8,7 +8,7 @@ import scipy.sparse.linalg
 import scipy.spatial.transform.rotation
 
 from . import Camera, ColoredTriMesh, LaplacianRigidEnergy, Scene3D, TriMesh
-from .tools import normalize, normalize_backward, qrot, qrot_backward
+from .tools import normalize, normalize_backward, qrot, qrot_backward, check_jacabian_finite_difference
 
 
 class MeshDepthFitter:
@@ -29,7 +29,7 @@ class MeshDepthFitter:
         self.inertia = inertia
         self.damping = damping
         self.step_factor_vertices = 0.0005
-        self.step_max_vertices = 0.5
+        self.step_max_vertices = 1
         self.step_factor_quaternion = 0.00006
         self.step_max_quaternion = 0.1
         self.step_factor_translation = 0.00005
@@ -416,20 +416,21 @@ class MeshRGBFitterWithPoseMultiFrame:
         default_color,
         default_light,
         cregu=2000,
-        inertia=0.96,
-        damping=0.05,
+        cdata=1,
+        inertia=0.97,
+        damping=0.15,
         update_lights=True,
         update_color=True,
     ):
         self.cregu = cregu
-
+        self.cdata = cdata
         self.inertia = inertia
         self.damping = damping
         self.step_factor_vertices = 0.0005
         self.step_max_vertices = 0.5
-        self.step_factor_quaternion = 0.00006
+        self.step_factor_quaternion = 0.00005
         self.step_max_quaternion = 0.05
-        self.step_factor_translation = 0.00005
+        self.step_factor_translation = 0.00004
         self.step_max_translation = 0.1
 
         self.default_color = default_color
@@ -570,17 +571,14 @@ class MeshRGBFitterWithPoseMultiFrame:
         )  # that will lead to a gradient that is in the tangeant space
         return
 
-    def step(self):
-        self.vertices = self.vertices - np.mean(self.vertices, axis=0)[None, :]
-
-        self.nb_facesrames = len(self.hand_images)
-
+    def energy_data(self, vertices, return_images=True):
+        self.vertices = vertices
         image = [None] * self.nb_facesrames
         diff_image = [None] * self.nb_facesrames
         image_b = [None] * self.nb_facesrames
         energy_datas = [None] * self.nb_facesrames
         self.clear_gradients()
-        coef_data = 1 / self.nb_facesrames
+        coef_data = self.cdata / self.nb_facesrames
         for idframe in range(self.nb_facesrames):
             image[idframe] = self.render(idframe=idframe)
             diff_image[idframe] = np.sum(
@@ -590,15 +588,39 @@ class MeshRGBFitterWithPoseMultiFrame:
             energy_datas[idframe] = coef_data * np.sum(diff_image[idframe])
             self.render_backward(image_b)
         energy_data = np.sum(energy_datas)
+        if return_images:
+            return energy_data, image, diff_image
+        else:
+            return energy_data
+
+    def step(self, check_gradient=False):
+   
+        self.vertices = self.vertices - np.mean(self.vertices, axis=0)[None, :]
+
+        self.nb_facesrames = len(self.hand_images)
+
+        energy_data, image, diff_image = self.energy_data(self.vertices)
         (
             energy_rigid,
             grad_rigidity,
             approx_hessian_rigidity,
         ) = self.rigid_energy.evaluate(self.vertices)
-        energy = energy_data + energy_rigid
-        print("Energy=%f : EData=%f E_rigid=%f" % (energy, energy_data, energy_rigid))
 
-        self.vertices_b = self.vertices_b - np.mean(self.vertices_b, axis=0)[None, :]
+        if check_gradient:
+            def func(x):
+                return self.rigid_energy.evaluate(x, return_grad=False, return_hessian=False)
+            check_jacabian_finite_difference(grad_rigidity.flatten(), func, self.vertices)
+
+            def func(x):
+                return self.energy_data(x, return_images=False)
+            grad_data = self.vertices_b.copy()
+            check_jacabian_finite_difference(grad_data.flatten(), func, self.vertices)
+
+        energy = energy_data + energy_rigid
+        print(f"iter {self.iter} Energy={energy} : EData={energy_data} E_rigid={energy_rigid}")
+
+        if self.iter < 500:
+            self.vertices_b = self.vertices_b - np.mean(self.vertices_b, axis=0)[None, :]
         # update v
         grad = self.vertices_b + grad_rigidity
 
@@ -611,11 +633,13 @@ class MeshRGBFitterWithPoseMultiFrame:
         step_vertices = mult_and_clamp(
             -grad, self.step_factor_vertices, self.step_max_vertices
         )
+
         self.speed_vertices = (1 - self.damping) * (
             self.speed_vertices * inertia + (1 - inertia) * step_vertices
         )
         self.vertices = self.vertices + self.speed_vertices
         # update rotation
+ 
         step_quaternion = mult_and_clamp(
             -self.transform_quaternion_b,
             self.step_factor_quaternion,

--- a/deodr/tools.py
+++ b/deodr/tools.py
@@ -48,3 +48,34 @@ def cross_backward(u, v, c_b):
     v_b = np.cross(c_b, u)
     u_b = np.cross(v, c_b)
     return u_b, v_b
+
+
+def jacabian_finite_difference(func, x, epsilon=1e-6):
+
+    v0 = func(x)
+    nx = x.copy()
+    J = np.zeros((v0.size, x.size))
+    for d in range(x.size):
+        nx.flat[d] = x.flat[d] + epsilon
+        d1 = func(nx)
+        nx.flat[d] = x.flat[d] - epsilon
+        d2 = func(nx)
+        nx.flat[d] = x.flat[d]
+        J[:, d] = (d1 - d2).flatten() / (2 * epsilon)
+    v02 = func(x)
+    assert v0 == v02
+    return J
+
+
+def check_jacabian_finite_difference(jac, func, x, epsilon=1e-7, tol=1e-4):
+
+    nx = x.copy()
+    for d in range(x.size):
+        nx.flat[d] = x.flat[d] + epsilon
+        d1 = func(nx)
+        nx.flat[d] = x.flat[d] - epsilon
+        d2 = func(nx)
+        nx.flat[d] = x.flat[d]
+        J_cold_fd = (d1 - d2).flatten() / (2 * epsilon)
+        max_diff = np.max(np.abs(jac[..., d] - J_cold_fd))
+        assert max_diff < tol

--- a/tests/test_depth_image_hand_fitting.py
+++ b/tests/test_depth_image_hand_fitting.py
@@ -12,7 +12,7 @@ def test_depth_image_hand_fitting_pytorch():
         save_images=False,
         max_iter=50,
     )
-    assert abs(energies[49] - 252.83065023526686) < 1e-5
+    assert abs(energies[49] - 251.3164869808227) < 1e-5
 
 
 def test_depth_image_hand_fitting_numpy():
@@ -24,7 +24,7 @@ def test_depth_image_hand_fitting_numpy():
         save_images=False,
         max_iter=50,
     )
-    assert abs(energies[49] - 253.03801111458935) < 1e-5
+    assert abs(energies[49] - 251.32711113730954) < 1e-5
 
 
 def test_depth_image_hand_fitting_tensorflow():
@@ -36,7 +36,7 @@ def test_depth_image_hand_fitting_tensorflow():
         save_images=False,
         max_iter=50,
     )
-    assert abs(energies[49] - 252.830650232813) < 1e-5
+    assert abs(energies[49] - 251.31648983466366) < 1e-5
 
 
 if __name__ == "__main__":

--- a/tests/test_rgb_image_hand_fitting.py
+++ b/tests/test_rgb_image_hand_fitting.py
@@ -24,7 +24,7 @@ def test_rgb_image_hand_fitting_numpy():
         save_images=False,
         max_iter=50,
     )
-    assert abs(energies[49] - 2122.2359691357165) < 2
+    assert abs(energies[49] - 2113.7013184079137) < 2
 
 
 def test_rgb_image_hand_fitting_tensorflow():
@@ -36,7 +36,7 @@ def test_rgb_image_hand_fitting_tensorflow():
         save_images=False,
         max_iter=50,
     )
-    assert abs(energies[49] - 2109.2460894774995) < 1
+    assert abs(energies[49] - 2107.0089187104204) < 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- making code to compute x_range more robust by avoiding division when ratio is large, this solve problem with part of edges where antialiasing was not applied for near vertical edges.
- changing the edge equation to be independent of vertex order (up to sign) to avoid gaps in diagonals (issue https://github.com/martinResearch/DEODR/issues/61)
- tuning multiview hand fitting to address issue https://github.com/martinResearch/DEODR/issues/21